### PR TITLE
Harden serialization of regular expressions.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,7 @@ function serialize (source, opts) {
     out += !/^\s*(function|\([^)]*\)\s*=>)/m.test(tmp) ? 'function ' + tmp : tmp
   } else if (util.isObject(source)) {
     if (util.isRegExp(source)) {
-      out += 'new RegExp("' + source.source.replace(/<\/script/ig, '<\\/script') + '", "' + source.flags + '")'
+      out += 'new RegExp(' + serialize(source.source) + ', "' + source.flags + '")'
     } else if (util.isDate(source)) {
       out += 'new Date("' + source.toJSON() + '")'
     } else if (util.isError(source)) {

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -144,8 +144,14 @@ module.exports = {
   'regexXss': [
     /[</script><script>alert('xss')//]/i,
     isLessV12
-      ? 'new RegExp("[<\\/script><script>alert(\'xss\')\\/\\/]", "i")'
-      : 'new RegExp("[<\\/script><script>alert(\'xss\')//]", "i")'
+      ? 'new RegExp("[\\u003C\\\\\\u002Fscript\\u003E\\u003Cscript\\u003Ealert(\'xss\')\\\\\\u002F\\\\\\u002F]", "i")'
+      : 'new RegExp("[\\u003C\\u002Fscript\\u003E\\u003Cscript\\u003Ealert(\'xss\')\\u002F\\u002F]", "i")'
+  ],
+  'regexXss2': [
+    /[</ script><script>alert('xss')//]/i,
+    isLessV12
+      ? 'new RegExp("[\\u003C\\\\\\u002F script\\u003E\\u003Cscript\\u003Ealert(\'xss\')\\\\\\u002F\\\\\\u002F]", "i")'
+      : 'new RegExp("[\\u003C\\u002F script\\u003E\\u003Cscript\\u003Ealert(\'xss\')\\u002F\\u002F]", "i")'
   ],
   'regex no flags': [
     /abc/,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -122,4 +122,11 @@ describe('#serialize', function () {
     var exp = '{a: {"3": "3", one: true, "thr-ee": undefined, "4 four": "four\\n<test></test>", "five\\"(5)": 5}, b: {"3": "3", one: true, "thr-ee": undefined, "4 four": "four\\n<test></test>", "five\\"(5)": 5}}'
     assert.strictEqual(res, exp)
   })
+  it('correctly serializes regular expressions', function () {
+    for (var re of [ /\//, /[</script><script>alert('xss')//]/i, /abc/, /[< /script>]/ ]) {
+      var re2 = eval(serialize(re)) // eslint-disable-line no-eval
+      assert.strictEqual(re.source, re2.source)
+      assert.strictEqual(re.flags, re2.flags)
+    }
+  })
 })


### PR DESCRIPTION
The escaping introduced in https://github.com/commenthol/serialize-to-js/commit/eac045c9409d814acbe223717b279c71a38ad679 is not quite sufficient, as the new test `regexXss2` shows. Instead of trying to match all possible ways an attacker might try to embed a `</script>` tag, it seems safer to just recursively serialize the source of the regular expression, which will do the necessary escaping.

The result is quite hard to read, though, so I added another test that serializes and then de-serializes (using `eval`) a few regular expressions and makes sure that their `.source` and `.flags` are preserved.